### PR TITLE
Fix for SWIG OpenCV namespace error

### DIFF
--- a/LBP.hpp
+++ b/LBP.hpp
@@ -44,8 +44,12 @@
 #ifndef _LBP_H_
 #define _LBP_H_
 
+// SWIG doesn't understand 'using' directives properly
+// so disable them if doing the SWIG pass
+#ifndef SWIG
 using namespace std;
 using namespace cv;
+#endif
 
 // enable/disable use of mixed OpenCV API in the code below.
 #define DEMO_MIXED_API_USE 0


### PR DESCRIPTION
'using' directive doesn't work with SWIG, so added preprocessor exclusion
